### PR TITLE
회원가입,로그인 API 파라미터 수정

### DIFF
--- a/build-logic/bin/main/convention/NetworkConvention.kt
+++ b/build-logic/bin/main/convention/NetworkConvention.kt
@@ -59,6 +59,7 @@ class NetworkConvention : Plugin<Project> {
                 val uploadCard: String = properties.getProperty("api_url_upload_card", "")
                 val banedChecked: String = properties.getProperty("api_url_upload_baned", "")
                 val answerCard: String = properties.getProperty("api_url_upload_card_answer", "")
+                val cardDistance: String = properties.getProperty("api_url_card_distance", "")
 
                 buildConfigField("String", "BASE_URL", baseUrl)
                 buildConfigField("String", "API_URL", apiUrl)
@@ -78,6 +79,7 @@ class NetworkConvention : Plugin<Project> {
                 buildConfigField("String", "API_URL_NOTIFICATION_READ", notificationRead)
                 buildConfigField("String", "API_URL_CARD_FEED_POPULAR", popularUrl)
                 buildConfigField("String", "API_URL_CARD_FEED_LATEST", latestUrl)
+                buildConfigField("String", "API_URL_CARD_FEED_DISTANCE", cardDistance)
                 buildConfigField("String", "API_URL_TAG_RELATED", relatedTag)
                 buildConfigField("String", "API_URL_CARD_IMAGE_DEFAULT", cardBackgroundImageDefault)
                 buildConfigField("String", "API_URL_UPLOAD_CARD_IMAGE", cardBackgroundUpload)

--- a/data/device/device_info/src/main/java/com/phew/device_info/DeviceInfo.kt
+++ b/data/device/device_info/src/main/java/com/phew/device_info/DeviceInfo.kt
@@ -2,5 +2,7 @@ package com.phew.device_info
 
 interface DeviceInfo {
     suspend fun deviceId(): String
+    suspend fun osVersion(): String
+    suspend fun modelName(): String
     suspend fun firebaseToken(): String
 }

--- a/data/device/device_info/src/main/java/com/phew/device_info/DeviceInfoImpl.kt
+++ b/data/device/device_info/src/main/java/com/phew/device_info/DeviceInfoImpl.kt
@@ -24,6 +24,24 @@ class DeviceInfoImpl @Inject constructor(@ApplicationContext private val context
         }
     }
 
+    override suspend fun osVersion(): String {
+        try {
+            return android.os.Build.VERSION.RELEASE
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw IllegalArgumentException("Device OS Version not fount ${e.message}")
+        }
+    }
+
+    override suspend fun modelName(): String {
+        try {
+            return android.os.Build.MODEL
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw IllegalArgumentException("Device Model Name not fount ${e.message}")
+        }
+    }
+
     override suspend fun firebaseToken(): String {
         try {
             val token = FirebaseMessaging.getInstance().token.await()

--- a/data/network/src/main/java/com/phew/network/dto/InfoDTO.kt
+++ b/data/network/src/main/java/com/phew/network/dto/InfoDTO.kt
@@ -6,4 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class InfoDTO(
     val encryptedDeviceId: String,
+    val deviceType: String,
+    val deviceOsVersion: String,
+    val deviceModel: String
 )

--- a/data/repository/src/main/java/com/phew/repository/DeviceRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/phew/repository/DeviceRepositoryImpl.kt
@@ -21,6 +21,14 @@ class DeviceRepositoryImpl @Inject constructor(
         return deviceInfo.deviceId()
     }
 
+    override suspend fun requestDeviceModel(): String {
+        return deviceInfo.modelName()
+    }
+
+    override suspend fun requestDeviceOS(): String {
+        return deviceInfo.osVersion()
+    }
+
     override suspend fun requestToken(key: String): Pair<String, String> {
         val data = dataStoreLocal.getToken(key)
         return Pair(data.refreshToken, data.accessToken)

--- a/data/repository/src/main/java/com/phew/repository/network/SignUpRepositoryImpl.kt
+++ b/data/repository/src/main/java/com/phew/repository/network/SignUpRepositoryImpl.kt
@@ -17,9 +17,14 @@ import okhttp3.RequestBody
 import javax.inject.Inject
 
 class SignUpRepositoryImpl @Inject constructor(private val signUpHttp : SignUpHttp) : SignUpRepository {
-    override suspend fun requestCheckSignUp(info: String): DataResult<CheckSignUp> {
+    override suspend fun requestCheckSignUp(info: String, osVersion: String, modelName: String): DataResult<CheckSignUp> {
         return apiCall(
-            apiCall = { signUpHttp.requestCheckSignUp(InfoDTO(info)) },
+            apiCall = { signUpHttp.requestCheckSignUp(InfoDTO(
+                encryptedDeviceId = info,
+                deviceType = "ANDROID",
+                deviceOsVersion = osVersion,
+                deviceModel = modelName
+            )) },
             mapper = { result -> result.toDomain() }
         )
     }
@@ -31,9 +36,18 @@ class SignUpRepositoryImpl @Inject constructor(private val signUpHttp : SignUpHt
         )
     }
 
-    override suspend fun requestLogin(info: String): DataResult<Token> {
+    override suspend fun requestLogin(
+        info: String,
+        osVersion: String,
+        modelName: String
+    ): DataResult<Token> {
         return apiCall(
-            apiCall = { signUpHttp.requestLogin(InfoDTO(encryptedDeviceId = info)) },
+            apiCall = { signUpHttp.requestLogin(InfoDTO(
+                encryptedDeviceId = info,
+                deviceType = "ANDROID",
+                deviceOsVersion = osVersion,
+                deviceModel = modelName
+            )) },
             mapper = { result -> result.toDomain() }
         )
     }

--- a/domain/src/main/java/com/phew/domain/repository/DeviceRepository.kt
+++ b/domain/src/main/java/com/phew/domain/repository/DeviceRepository.kt
@@ -6,6 +6,8 @@ import com.phew.domain.dto.UserInfo
 
 interface DeviceRepository {
     suspend fun requestDeviceId(): String
+    suspend fun requestDeviceModel(): String
+    suspend fun requestDeviceOS(): String
     suspend fun requestToken(key: String): Pair<String, String>
     suspend fun saveToken(key: String, data: Token): Boolean
     suspend fun firebaseToken(): String

--- a/domain/src/main/java/com/phew/domain/repository/network/SignUpRepository.kt
+++ b/domain/src/main/java/com/phew/domain/repository/network/SignUpRepository.kt
@@ -7,9 +7,9 @@ import com.phew.domain.dto.UploadImageUrl
 import okhttp3.RequestBody
 
 interface SignUpRepository {
-    suspend fun requestCheckSignUp(info: String): DataResult<CheckSignUp>
+    suspend fun requestCheckSignUp(info: String, osVersion: String, modelName: String): DataResult<CheckSignUp>
     suspend fun requestSecurityKey(): DataResult<String>
-    suspend fun requestLogin(info: String): DataResult<Token>
+    suspend fun requestLogin(info: String, osVersion: String, modelName: String): DataResult<Token>
     suspend fun requestNickName(): DataResult<String>
     suspend fun requestUploadImageUrl(): DataResult<UploadImageUrl>
     suspend fun requestUploadImage(data: RequestBody, url: String): DataResult<Unit>

--- a/domain/src/main/java/com/phew/domain/usecase/CheckSignUp.kt
+++ b/domain/src/main/java/com/phew/domain/usecase/CheckSignUp.kt
@@ -12,6 +12,8 @@ import com.phew.domain.SIGN_UP_BANNED
 import com.phew.domain.SIGN_UP_OKAY
 import com.phew.domain.SIGN_UP_WITHDRAWN
 import com.phew.domain.repository.network.SignUpRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import java.security.spec.X509EncodedKeySpec
 import java.security.KeyFactory
 import javax.crypto.Cipher
@@ -20,16 +22,28 @@ class CheckSignUp @Inject constructor(
     private val deviceRepository: DeviceRepository,
     private val repository: SignUpRepository,
 ) {
-    suspend operator fun invoke(): DomainResult<Pair<String, String>, String> {
+    suspend operator fun invoke(): DomainResult<Pair<String, String>, String> = coroutineScope {
         val securityKeyResult = repository.requestSecurityKey()
         if (securityKeyResult is DataResult.Fail) {
-            return DomainResult.Failure(ERROR_NETWORK)
+            return@coroutineScope DomainResult.Failure(ERROR_NETWORK)
         }
         val securityKey = (securityKeyResult as DataResult.Success).data
         val key = makeSecurityKey(securityKey)
-        val deviceId = deviceRepository.requestDeviceId()
+
+        val deviceIdDeferred = async { deviceRepository.requestDeviceId() }
+        val osVersionDeferred = async { deviceRepository.requestDeviceOS() }
+        val modelNameDeferred = async { deviceRepository.requestDeviceModel() }
+
+        val deviceId = deviceIdDeferred.await()
+        val osVersion = osVersionDeferred.await()
+        val modelName = modelNameDeferred.await()
+
         val encryptedInfo = encrypt(data = deviceId, key = key)
-        return when (val checkSignUpResult = repository.requestCheckSignUp(encryptedInfo)) {
+        when (val checkSignUpResult = repository.requestCheckSignUp(
+            info = encryptedInfo,
+            osVersion = osVersion,
+            modelName = modelName
+        )) {
             is DataResult.Fail -> {
                 DomainResult.Failure(ERROR_NETWORK)
             }


### PR DESCRIPTION
- 파라미터 기기모델, OS버전, Type 추가
- 추가 수정 사항
 **  Login: deviceId, osVersion, modelName, requestKey를 가져오는 4가지 요청을 동시에
     실행하도록 수정했습니다. requestKey 요청이 실패하면 다른 요청의 결과를 기다리지 않고
     즉시 실패를 반환하여 불필요한 대기 시간을 줄였습니다.

  **  CheckSignUp: deviceId, osVersion, modelName을 가져오는 3가지 요청을 동시에 실행하도록
     수정하여 여러 요청을 병렬로 처리하고 응답 시간을 단축했습니다.